### PR TITLE
Clamp MemoryBar

### DIFF
--- a/packages/jupyterlab-system-monitor/src/memoryView.tsx
+++ b/packages/jupyterlab-system-monitor/src/memoryView.tsx
@@ -33,7 +33,7 @@ export class MemoryView extends VDomRenderer<MemoryUsage.Model> {
     }
     const { memoryLimit, currentMemory, units } = this.model;
     const text = `${currentMemory.toFixed(2)} ${memoryLimit ? '/ ' + memoryLimit.toFixed(2) : ''} ${units}`;
-    let percentage = memoryLimit ? (currentMemory / memoryLimit) * 100 : null;
+    let percentage = memoryLimit ? Math.min((currentMemory / memoryLimit) * 100, 100) : null;
     return (
         <div className="jp-MemoryContainer" style={percentage && { width: '200px' }}>
             <div className="jp-MemoryText">Mem: </div>


### PR DESCRIPTION
To avoid the indicator to go above the outline.