### PR TITLE
Remove margin from the sparklines svg

### DIFF
--- a/packages/jupyterlab-system-monitor/src/memoryView.tsx
+++ b/packages/jupyterlab-system-monitor/src/memoryView.tsx
@@ -60,9 +60,8 @@ class MemoryBar extends React.Component<IMemoryBarProps, IMemoryBarState> {
           min={0.0}
           max={1.0}
           limit={N_BUFFER}
-          preserveAspectRatio={"xMidYMax slice"}
-          svgHeight={"100%"}
-          svgWidth={"100%"}
+          width={250}
+          margin={0}
         >
           <SparklinesLine
             style={{


### PR DESCRIPTION
So the graph is better aligned.

![memory-sparklines](https://user-images.githubusercontent.com/591645/52975685-b4b7db00-33c6-11e9-942d-902bc147958a.gif)

