### PR TITLE
New extension: jupyterlab-logout

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -11,6 +11,7 @@ yarn install
 yarn run build
 
 jupyter labextension link ./packages/jupyterlab-topbar --no-build
+jupyter labextension install ./packages/jupyterlab-logout
 jupyter labextension install ./packages/jupyterlab-topbar-extension
 jupyter labextension install ./packages/jupyterlab-topbar-text
 jupyter labextension install ./packages/jupyterlab-system-monitor

--- a/packages/jupyterlab-logout/.gitignore
+++ b/packages/jupyterlab-logout/.gitignore
@@ -1,0 +1,5 @@
+*.bundle.*
+lib/
+node_modules/
+*.egg-info/
+.ipynb_checkpoints

--- a/packages/jupyterlab-logout/README.md
+++ b/packages/jupyterlab-logout/README.md
@@ -1,0 +1,32 @@
+# jupyterlab-logout
+
+Logout Button for JupyterLab
+
+
+## Prerequisites
+
+* JupyterLab
+
+## Installation
+
+```bash
+jupyter labextension install jupyterlab-logout
+```
+
+## Development
+
+For a development install (requires npm version 4 or later), do the following in the repository directory:
+
+```bash
+npm install
+npm run build
+jupyter labextension link .
+```
+
+To rebuild the package and the JupyterLab app:
+
+```bash
+npm run build
+jupyter lab build
+```
+

--- a/packages/jupyterlab-logout/package.json
+++ b/packages/jupyterlab-logout/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "jupyterlab-logout",
+  "version": "0.1.0",
+  "description": "Logout Button for JupyterLab",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/jtpio/jupyterlab-topbar",
+  "bugs": {
+    "url": "https://github.com/jtpio/jupyterlab-topbar/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Jeremy Tuloup",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jtpio/jupyterlab-topbar.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "prepare": "npm run clean && npm run build",
+    "watch": "tsc -w"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^1.0.0-alpha.6",
+    "@phosphor/widgets": "^1.6.0",
+    "jupyterlab-topbar": "^0.1.1"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.1",
+    "typescript": "~3.1.1"
+  },
+  "jupyterlab": {
+    "extension": true
+  }
+}

--- a/packages/jupyterlab-logout/src/index.ts
+++ b/packages/jupyterlab-logout/src/index.ts
@@ -1,0 +1,35 @@
+import {
+  JupyterFrontEnd, JupyterFrontEndPlugin, IRouter
+} from '@jupyterlab/application';
+
+import { Widget } from '@phosphor/widgets';
+
+import { ITopBar } from "jupyterlab-topbar";
+
+import '@jupyterlab/application/style/buttons.css';
+
+import '../style/index.css';
+
+const extension: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlab-logout',
+  autoStart: true,
+  requires: [IRouter, ITopBar],
+  activate: async (
+    app: JupyterFrontEnd,
+    router: IRouter,
+    topBar: ITopBar,
+  ) => {
+    let logout = document.createElement('a');
+    logout.id = "logout";
+    logout.innerHTML = "Log Out";
+    logout.addEventListener('click', function () {
+      router.navigate('/logout', { hard: true });
+    });
+
+    const widget = new Widget({node: logout});
+    widget.addClass('jp-Button-flat');
+    topBar.addItem("logout-button", widget);
+  }
+};
+
+export default extension;

--- a/packages/jupyterlab-logout/tsconfig.json
+++ b/packages/jupyterlab-logout/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "preserveWatchOutput": true,
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": false,
+    "target": "es2015",
+    "types": []
+  },
+  "include": ["src/*"]
+}

--- a/packages/jupyterlab-topbar/style/index.css
+++ b/packages/jupyterlab-topbar/style/index.css
@@ -27,4 +27,10 @@
   background-color: var(--md-blue-400);
   color: var(--jp-content-font-color1);
   opacity: 0.5;
+  cursor: move;
+}
+
+.jp-TopBar-DropTarget:hover {
+  background-color: var(--md-blue-400) !important;
+  cursor: move !important;
 }


### PR DESCRIPTION
Fixes #19.

New `jupyterlab-logout` extension to add a "Log Out" button in the top bar area.

![logout](https://user-images.githubusercontent.com/591645/57317075-90cb8200-70f7-11e9-9be3-d062af4f4c70.gif)


### TODO

- [x] Check the spelling: "Log Out" (lab) vs "Logout" (classic notebook)
- [x] Decide on the style of the button
