### PR TITLE
Add MOVED TO disclaimer for jupyterlab-system-monitor

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -14,5 +14,4 @@ jupyter labextension link ./packages/jupyterlab-topbar
 jupyter labextension install ./packages/jupyterlab-logout \
                              ./packages/jupyterlab-topbar-extension \
                              ./packages/jupyterlab-topbar-text \
-                             ./packages/jupyterlab-system-monitor \
                              ./packages/jupyterlab-theme-toggle

--- a/packages/jupyterlab-system-monitor/README.md
+++ b/packages/jupyterlab-system-monitor/README.md
@@ -1,5 +1,7 @@
 # JupyterLab System Monitor
 
+**MOVED TO https://github.com/jtpio/jupyterlab-system-monitor**
+
 JupyterLab extension to display system information (memory and cpu usage).
 
 Provides an alternative frontend for the `nbresuse` metrics: [https://github.com/yuvipanda/nbresuse](https://github.com/yuvipanda/nbresuse)


### PR DESCRIPTION
Moved the `jupyterlab-system-monitor` extension to https://github.com/jtpio/jupyterlab-system-monitor