### PR TITLE
Move theme-toggle extension to its own repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Inspired by Gnome Shell Top Bar indicators.
 - [jupyterlab-topbar-text](./packages/jupyterlab-topbar-text): add and edit custom text
 - [jupyterlab-system-monitor](https://github.com/jtpio/jupyterlab-system-monitor): show system metrics (memory usage)
 - [jupyterlab-logout](./packages/jupyterlab-logout): add a "Log Out" button
-- [jupyterlab-theme-toggle](./packages/jupyterlab-theme-toggle): switch between the Light and Dark themes
+- [jupyterlab-theme-toggle](https://github.com/jtpio/jupyterlab-theme-toggle): switch between the Light and Dark themes
 
 ## Try it online
 

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -13,5 +13,4 @@ yarn run build
 jupyter labextension link ./packages/jupyterlab-topbar
 jupyter labextension install ./packages/jupyterlab-logout \
                              ./packages/jupyterlab-topbar-extension \
-                             ./packages/jupyterlab-topbar-text \
-                             ./packages/jupyterlab-theme-toggle
+                             ./packages/jupyterlab-topbar-text

--- a/packages/jupyterlab-theme-toggle/README.md
+++ b/packages/jupyterlab-theme-toggle/README.md
@@ -1,5 +1,7 @@
 # jupyterlab-theme-toggle
 
+**MOVED TO https://github.com/jtpio/jupyterlab-theme-toggle**
+
 JupyterLab extension to toggle the theme in the Top Bar area
 
 


### PR DESCRIPTION
Moved the `jupyterlab-theme-toggle` extension to its own repo: https://github.com/jtpio/jupyterlab-theme-toggle