### PR TITLE
Move jupyterlab-logout to its own repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Inspired by Gnome Shell Top Bar indicators.
 - [jupyterlab-topbar-extension](./packages/jupyterlab-topbar-extension): generic extension to expose the top bar area
 - [jupyterlab-topbar-text](./packages/jupyterlab-topbar-text): add and edit custom text
 - [jupyterlab-system-monitor](https://github.com/jtpio/jupyterlab-system-monitor): show system metrics (memory usage)
-- [jupyterlab-logout](./packages/jupyterlab-logout): add a "Log Out" button
+- [jupyterlab-logout](https://github.com/jtpio/jupyterlab-logout): add a "Log Out" button
 - [jupyterlab-theme-toggle](https://github.com/jtpio/jupyterlab-theme-toggle): switch between the Light and Dark themes
 
 ## Try it online

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -11,6 +11,5 @@ yarn install
 yarn run build
 
 jupyter labextension link ./packages/jupyterlab-topbar
-jupyter labextension install ./packages/jupyterlab-logout \
-                             ./packages/jupyterlab-topbar-extension \
+jupyter labextension install ./packages/jupyterlab-topbar-extension \
                              ./packages/jupyterlab-topbar-text

--- a/packages/jupyterlab-logout/README.md
+++ b/packages/jupyterlab-logout/README.md
@@ -1,11 +1,12 @@
 # jupyterlab-logout
 
-Logout Button for JupyterLab
+**MOVED TO https://github.com/jtpio/jupyterlab-logout**
 
+Logout Button for JupyterLab.
 
 ## Prerequisites
 
-* JupyterLab
+* JupyterLab 1.0+
 
 ## Installation
 


### PR DESCRIPTION
Moved the `jupyterlab-logout` extension to its own repo: https://github.com/jtpio/jupyterlab-logout.