### PR TITLE
Add editable flag to the topbar-text settings

### DIFF
--- a/packages/jupyterlab-topbar-text/schema/plugin.json
+++ b/packages/jupyterlab-topbar-text/schema/plugin.json
@@ -9,6 +9,12 @@
       "description": "Text to display",
       "default": "Hi There 👋",
       "type": "string"
+    },
+    "editable": {
+      "title": "Editable",
+      "description": "Whether the text can be edited via the UI",
+      "default": true,
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/packages/jupyterlab-topbar-text/src/index.ts
+++ b/packages/jupyterlab-topbar-text/src/index.ts
@@ -36,6 +36,7 @@ const extension: JupyterFrontEndPlugin<void> = {
   ) => {
     const settings = await settingsRegistry.load(extension.id);
     let text = settings.get("text").composite as string;
+    let editable = settings.get("editable").composite as boolean;
     let textNode = document.createElement('div');
     textNode.textContent = text;
     let textWidget = new Widget({ node: textNode });
@@ -75,7 +76,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       label: "Edit Text",
       execute: (args: any) => {
         showUpdateTextDialog();
-      }
+      },
+      isEnabled: () => editable
     });
 
     if (palette) {
@@ -86,6 +88,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     app.restored.then(() => {
       settings.changed.connect(async () => {
         text = settings.get("text").composite as string;
+        editable = settings.get("editable").composite as boolean;
         textNode.textContent = text;
       });
     });


### PR DESCRIPTION
Fixes #43. 

![editable-text](https://user-images.githubusercontent.com/591645/81051370-df099180-8ec1-11ea-94e4-f187c1dca5d5.gif)
